### PR TITLE
feat: Add Constant Propagation Analysis for more clang::Stmt, and provide map from clang::Expr to its CPValue

### DIFF
--- a/include/analysis/dataflow/ConstantPropagation.h
+++ b/include/analysis/dataflow/ConstantPropagation.h
@@ -119,7 +119,8 @@ namespace analyzer::analysis::dataflow {
         bool update(const std::shared_ptr<ir::Var>& key, const std::shared_ptr<CPValue>& value) override;
 
     };
-    
+
+
     /**
      * @class ConstantPropagation
      * @brief constant propagation analysis
@@ -133,7 +134,18 @@ namespace analyzer::analysis::dataflow {
          */
         explicit ConstantPropagation(std::unique_ptr<config::AnalysisConfig>& analysisConfig);
 
+        /**
+         * @brief get the CPValue of a given clang Expr
+         * @param expr the clang Expr to be searched
+         * @return the CPValue to which the specified key is mapped,
+         * or nullptr if this map contains no mapping for the given clang Expr
+         */
+        [[nodiscard]] std::shared_ptr<CPValue> getExprValue(const clang::Expr *expr) const;
+
     protected:
+
+        std::shared_ptr<std::unordered_map<const clang::Expr*, std::shared_ptr<CPValue>>>
+            exprValues;
 
         [[nodiscard]] std::unique_ptr<DataflowAnalysis<CPFact>>
             makeAnalysis(const std::shared_ptr<graph::CFG>& cfg) const override;

--- a/include/analysis/dataflow/ConstantPropagation.h
+++ b/include/analysis/dataflow/ConstantPropagation.h
@@ -122,6 +122,31 @@ namespace analyzer::analysis::dataflow {
 
 
     /**
+     * @class CPResult
+     * @brief constant propagation result
+     */
+    class CPResult : public fact::DataflowResult<CPFact> {
+    public:
+    
+        /**
+         * @brief constructor for constant propagation result
+         * @param exprValues the map from clang expr to constant propagation value
+         */
+        explicit CPResult(std::shared_ptr<std::unordered_map<const clang::Expr*, std::shared_ptr<CPValue>>> exprValues);
+
+        /**
+         * @brief get the constant propagation value of a given clang expr
+         * @param expr the clang expr to be searched
+         * @return the constant propagation value to which the specified clang expr is mapped,
+         * or nullptr if this map contains no mapping for the given clang expr
+         */
+        [[nodiscard]] std::shared_ptr<CPValue> getExprValue(const clang::Expr* expr) const;
+
+    private:
+        std::shared_ptr<std::unordered_map<const clang::Expr*, std::shared_ptr<CPValue>>> exprValues;
+    };
+
+    /**
      * @class ConstantPropagation
      * @brief constant propagation analysis
      */
@@ -134,18 +159,7 @@ namespace analyzer::analysis::dataflow {
          */
         explicit ConstantPropagation(std::unique_ptr<config::AnalysisConfig>& analysisConfig);
 
-        /**
-         * @brief get the CPValue of a given clang Expr
-         * @param expr the clang Expr to be searched
-         * @return the CPValue to which the specified key is mapped,
-         * or nullptr if this map contains no mapping for the given clang Expr
-         */
-        [[nodiscard]] std::shared_ptr<CPValue> getExprValue(const clang::Expr *expr) const;
-
     protected:
-
-        std::shared_ptr<std::unordered_map<const clang::Expr*, std::shared_ptr<CPValue>>>
-            exprValues;
 
         [[nodiscard]] std::unique_ptr<DataflowAnalysis<CPFact>>
             makeAnalysis(const std::shared_ptr<graph::CFG>& cfg) const override;

--- a/resources/dataflow/ConstPropagation/ConstPropagationTest.cpp
+++ b/resources/dataflow/ConstPropagation/ConstPropagationTest.cpp
@@ -7,19 +7,33 @@ class ConstPropagation {
     int dummy() {
         int x;
         int y;
-        x = 1;
-        y = x;
+        y = x = 1;
         return y;
+    }
+
+    void typeCast() {
+        char a = 'a';
+        int x = (int)(char)10000000;
+        long long y = (long long)1000000000000000000;
+        unsigned long long z = (unsigned long long)(unsigned int)-1;
     }
 
     int ifElse(int n) {
         int x, y, z, a;
+        int u, v;
         if (n > 0) {
             x = 1;
             y = 3;
+            if (n == 1) {
+                u = 2;
+                v = 2;
+            }
         } else {
             x = 2;
             y = 3;
+            if (n == 0) {
+                v = 3;
+            }
         }
         z = x + y;
         return z;
@@ -42,4 +56,40 @@ class ConstPropagation {
         n /= zero;
         return n;
     }
+
+     int loop() {
+        int a = 10, b = 2, c;
+        while (a > b) {
+            c = b;
+            --a;
+        }
+        return c;
+    }
+
+    void incDec() {
+        int x = 0;
+        int y = 0;
+        x++;
+        y--;
+        int a = x++;
+        int b = ++x;
+        int c = y--;
+        int d = --y;
+    }
+
+    int array() {
+        int a[2][2];
+        int i = 2, j = 3;
+        return a[i][j];
+    }
+
+    int foo(int n) {
+        return n;
+    }
+
+    int call() {
+        int zero = 0;
+        return foo(1 / zero);
+    }
+
 };

--- a/tests/TestConstantPropagation.cpp
+++ b/tests/TestConstantPropagation.cpp
@@ -14,21 +14,20 @@ namespace dfact = al::analysis::dataflow::fact;
 
 class ConstPropagationTestFixture {
 protected:
-    std::shared_ptr<air::IR> ir1, ir2, ir3;
-    std::unique_ptr<df::ConstantPropagation> cp;
+    std::shared_ptr<air::IR> dummy, typeCast, ifElse, binaryOp, loop, incDec, array, call;
+    
 public:
     ConstPropagationTestFixture() {
         al::World::initialize("resources/dataflow/constPropagation");
         const al::World& world = al::World::get();
-        ir1 = world.getMethodBySignature("int ConstPropagation::dummy()")->getIR();
-        ir2 = world.getMethodBySignature("int ConstPropagation::ifElse(int)")->getIR();
-        ir3 = world.getMethodBySignature("int ConstPropagation::binaryOp(int)")->getIR();
-
-        std::unique_ptr<cf::AnalysisConfig> analysisConfig
-                = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
-        cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
-
-        CHECK_FALSE(analysisConfig);
+        dummy = world.getMethodBySignature("int ConstPropagation::dummy()")->getIR();
+        typeCast = world.getMethodBySignature("void ConstPropagation::typeCast()")->getIR();
+        ifElse = world.getMethodBySignature("int ConstPropagation::ifElse(int)")->getIR();
+        binaryOp = world.getMethodBySignature("int ConstPropagation::binaryOp(int)")->getIR();
+        loop = world.getMethodBySignature("int ConstPropagation::loop()")->getIR();
+        incDec = world.getMethodBySignature("void ConstPropagation::incDec()")->getIR();
+        array = world.getMethodBySignature("int ConstPropagation::array()")->getIR();
+        call = world.getMethodBySignature("int ConstPropagation::call()")->getIR();
     }
 };
 
@@ -40,42 +39,84 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCaseDummy"
 
     al::World::getLogger().Progress("Testing constant propagation example dummy ...");
 
-    std::shared_ptr<graph::CFG> cfg = ir1->getCFG();
+    std::shared_ptr<graph::CFG> cfg = dummy->getCFG();
     std::unordered_map<std::string, std::shared_ptr<air::Stmt>> stmtMap;
-    for (const std::shared_ptr<air::Stmt>& s : ir1->getStmts()) {
+    for (const std::shared_ptr<air::Stmt>& s : dummy->getStmts()) {
         al::World::getLogger().Debug(s->str());
         stmtMap.emplace(s->str(), s);
     }
 
     std::unordered_map<std::string, std::shared_ptr<air::Var>> varMap;
-    for (const std::shared_ptr<air::Var>& v : ir1->getVars()) {
+    for (const std::shared_ptr<air::Var>& v : dummy->getVars()) {
         varMap.emplace(v->getName(), v);
     }
 
     std::shared_ptr<air::Stmt> s1 = stmtMap.at("int x;");
     std::shared_ptr<air::Stmt> s2 = stmtMap.at("int y;");
-    std::shared_ptr<air::Stmt> s3 = stmtMap.at("x = 1");
-    std::shared_ptr<air::Stmt> s4 = stmtMap.at("y = x");
-    std::shared_ptr<air::Stmt> s5 = stmtMap.at("return y");
+    std::shared_ptr<air::Stmt> s3 = stmtMap.at("y = x = 1");
+    std::shared_ptr<air::Stmt> s4 = stmtMap.at("return y");
 
     std::shared_ptr<air::Var> x = varMap.at("x");
     std::shared_ptr<air::Var> y = varMap.at("y");
 
-    std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(ir1);
+    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
+    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
+    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
+    std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(dummy);
 
     CHECK(result->getOutFact(s1)->get(x)->isUndef());
     CHECK(result->getOutFact(s2)->get(x)->isUndef());
     auto s3_x = result->getOutFact(s3)->get(x);
     CHECK(s3_x->isConstant());
     CHECK_EQ(s3_x->getConstantValue(), 1);
-    auto s4_x = result->getOutFact(s4)->get(x);
-    CHECK(s4_x->isConstant());
-    CHECK_EQ(s4_x->getConstantValue(), 1);
-    auto s4_y = result->getOutFact(s4)->get(y);
-    CHECK(s4_y->isConstant());
-    CHECK_EQ(s4_y->getConstantValue(), 1);
+    auto s3_y = result->getOutFact(s4)->get(y);
+    CHECK(s3_y->isConstant());
+    CHECK_EQ(s3_y->getConstantValue(), 1);
 
     al::World::getLogger().Success("Finish testing constant propagation example dummy ...");
+
+}
+
+TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationTypeCase"
+    * doctest::description("testing constant propagation example type-cast")) {
+
+    al::World::getLogger().Progress("Testing constant propagation example type-cast ...");
+
+    std::shared_ptr<graph::CFG> cfg = typeCast->getCFG();
+    std::unordered_map<std::string, std::shared_ptr<air::Stmt>> stmtMap;
+    for (const std::shared_ptr<air::Stmt>& s : typeCast->getStmts()) {
+        al::World::getLogger().Debug(s->str());
+        stmtMap.emplace(s->str(), s);
+    }
+
+    std::unordered_map<std::string, std::shared_ptr<air::Var>> varMap;
+    for (const std::shared_ptr<air::Var>& v : typeCast->getVars()) {
+        varMap.emplace(v->getName(), v);
+    }
+
+    std::shared_ptr<air::Stmt> exit = cfg->getExit();
+
+    std::shared_ptr<air::Var> a = varMap.at("a");
+    std::shared_ptr<air::Var> x = varMap.at("x");
+    std::shared_ptr<air::Var> y = varMap.at("y");
+    std::shared_ptr<air::Var> z = varMap.at("z");
+
+    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
+    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
+    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
+    std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(typeCast);
+    auto fact = result->getInFact(exit);
+
+    CHECK(fact->get(a)->isConstant());
+    CHECK_EQ(fact->get(a)->getConstantValue(), (char)'a');
+    CHECK(fact->get(x)->isConstant());
+    CHECK_EQ(fact->get(x)->getConstantValue(), (int)(char)10000000);
+    CHECK(fact->get(y)->isConstant());
+    CHECK_EQ(fact->get(y)->getConstantValue(), (long long)1000000000000000000);
+    CHECK(fact->get(z)->isConstant());
+    CHECK_EQ(fact->get(z)->getConstantValue(), (unsigned long long)(unsigned int)-1);
+
+    al::World::getLogger().Success("Finish testing constant propagation example type-cast ...");
 
 }
 
@@ -84,15 +125,15 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCaseIfElse"
 
     al::World::getLogger().Progress("Testing constant propagation example if-else ...");
 
-    std::shared_ptr<graph::CFG> cfg = ir2->getCFG();
+    std::shared_ptr<graph::CFG> cfg = ifElse->getCFG();
     std::unordered_map<std::string, std::shared_ptr<air::Stmt>> stmtMap;
-    for (const std::shared_ptr<air::Stmt>& s : ir2->getStmts()) {
+    for (const std::shared_ptr<air::Stmt>& s : ifElse->getStmts()) {
        al::World::getLogger().Debug(s->str());
        stmtMap.emplace(s->str(), s);
     }
 
     std::unordered_map<std::string, std::shared_ptr<air::Var>> varMap;
-    for (const std::shared_ptr<air::Var>& v : ir2->getVars()) {
+    for (const std::shared_ptr<air::Var>& v : ifElse->getVars()) {
        varMap.emplace(v->getName(), v);
     }
 
@@ -103,8 +144,13 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCaseIfElse"
     std::shared_ptr<air::Var> y = varMap.at("y");
     std::shared_ptr<air::Var> z = varMap.at("z");
     std::shared_ptr<air::Var> a = varMap.at("a");
+    std::shared_ptr<air::Var> u = varMap.at("u");
+    std::shared_ptr<air::Var> v = varMap.at("v");
 
-    std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(ir2);
+    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
+    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
+    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
+    std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(ifElse);
     auto fact = result->getInFact(exit);
 
     CHECK(fact->get(n)->isNAC());
@@ -113,6 +159,9 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCaseIfElse"
     CHECK_EQ(fact->get(y)->getConstantValue(), 3);
     CHECK(fact->get(z)->isNAC());
     CHECK(fact->get(a)->isUndef());
+    CHECK(fact->get(u)->isConstant());
+    CHECK_EQ(fact->get(u)->getConstantValue(), 2);
+    CHECK(fact->get(v)->isNAC());
 
     al::World::getLogger().Success("Finish constant propagation example if-else ...");
 
@@ -123,15 +172,15 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCaseBinaryOp
 
     al::World::getLogger().Progress("Testing constant propagation example binary-op ...");
 
-    std::shared_ptr<graph::CFG> cfg = ir3->getCFG();
+    std::shared_ptr<graph::CFG> cfg = binaryOp->getCFG();
     std::unordered_map<std::string, std::shared_ptr<air::Stmt>> stmtMap;
-    for (const std::shared_ptr<air::Stmt>& s : ir3->getStmts()) {
+    for (const std::shared_ptr<air::Stmt>& s : binaryOp->getStmts()) {
        al::World::getLogger().Debug(s->str());
        stmtMap.emplace(s->str(), s);
     }
 
     std::unordered_map<std::string, std::shared_ptr<air::Var>> varMap;
-    for (const std::shared_ptr<air::Var>& v : ir3->getVars()) {
+    for (const std::shared_ptr<air::Var>& v : binaryOp->getVars()) {
        varMap.emplace(v->getName(), v);
     }
 
@@ -153,8 +202,10 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCaseBinaryOp
     std::shared_ptr<air::Var> RShift = varMap.at("RShift");
     std::shared_ptr<air::Var> zero = varMap.at("zero");
 
-
-    std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(ir3);
+    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
+    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
+    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
+    std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(binaryOp);
     CHECK(result->getOutFact(cfg->getEntry())->get(n)->isNAC());
 
     auto fact = result->getInFact(exit);
@@ -190,6 +241,183 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCaseBinaryOp
 
     al::World::getLogger().Success("Finish constant propagation example binary-op ...");
 
+}
+
+TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCaseLoop"
+    * doctest::description("testing constant propagation example loop")) {
+    
+    al::World::getLogger().Progress("Testing constant propagation example loop ...");
+
+    std::shared_ptr<graph::CFG> cfg = loop->getCFG();
+    std::unordered_map<std::string, std::shared_ptr<air::Stmt>> stmtMap;
+    for (const std::shared_ptr<air::Stmt>& s : loop->getStmts()) {
+       al::World::getLogger().Debug(s->str());
+       stmtMap.emplace(s->str(), s);
+    }
+
+    std::unordered_map<std::string, std::shared_ptr<air::Var>> varMap;
+    for (const std::shared_ptr<air::Var>& v : loop->getVars()) {
+       varMap.emplace(v->getName(), v);
+    }
+
+    std::shared_ptr<air::Stmt> exit = cfg->getExit();
+
+    std::shared_ptr<air::Var> a = varMap.at("a");
+    std::shared_ptr<air::Var> c = varMap.at("c");
+
+    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
+    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
+    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
+    std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(loop);
+
+    auto fact = result->getInFact(exit);
+    CHECK(fact->get(a)->isNAC());
+    CHECK(fact->get(c)->isConstant());
+    CHECK_EQ(fact->get(c)->getConstantValue(), 2);
+
+    al::World::getLogger().Success("Finish constant propagation example loop ...");
+}
+
+TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationIncDec"
+    * doctest::description("testing constant propagation example inc-dec")) {
+    
+    al::World::getLogger().Progress("Testing constant propagation example inc-dec ...");
+
+    std::shared_ptr<graph::CFG> cfg = incDec->getCFG();
+    std::unordered_map<std::string, std::shared_ptr<air::Stmt>> stmtMap;
+    for (const std::shared_ptr<air::Stmt>& s : incDec->getStmts()) {
+       al::World::getLogger().Debug(s->str());
+       stmtMap.emplace(s->str(), s);
+    }
+
+    std::unordered_map<std::string, std::shared_ptr<air::Var>> varMap;
+    for (const std::shared_ptr<air::Var>& v : incDec->getVars()) {
+       varMap.emplace(v->getName(), v);
+    }
+
+    std::shared_ptr<air::Stmt> exit = cfg->getExit();
+
+    std::shared_ptr<air::Var> a = varMap.at("a");
+    std::shared_ptr<air::Var> b = varMap.at("b");
+    std::shared_ptr<air::Var> c = varMap.at("c");
+    std::shared_ptr<air::Var> d = varMap.at("d");
+
+    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
+    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
+    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
+    std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(incDec);
+
+    auto fact = result->getInFact(exit);
+    CHECK(fact->get(a)->isConstant());
+    CHECK_EQ(fact->get(a)->getConstantValue(), 1);
+    CHECK(fact->get(b)->isConstant());
+    CHECK_EQ(fact->get(b)->getConstantValue(), 3);
+    CHECK(fact->get(c)->isConstant());
+    CHECK_EQ(fact->get(c)->getConstantValue(), -1);
+    CHECK(fact->get(d)->isConstant());
+    CHECK_EQ(fact->get(d)->getConstantValue(), -3);
+
+    al::World::getLogger().Success("Finish constant propagation example inc-dec ...");
+}
+
+TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationArray"
+    * doctest::description("testing constant propagation example array")) {
+
+    al::World::getLogger().Progress("Testing constant propagation example array ...");
+
+    std::shared_ptr<graph::CFG> cfg = array->getCFG();
+    std::unordered_map<std::string, std::shared_ptr<air::Stmt>> stmtMap;
+    for (const std::shared_ptr<air::Stmt>& s : array->getStmts()) {
+       al::World::getLogger().Debug(s->str());
+       stmtMap.emplace(s->str(), s);
+    }
+
+    std::unordered_map<std::string, std::shared_ptr<air::Var>> varMap;
+    for (const std::shared_ptr<air::Var>& v : array->getVars()) {
+       varMap.emplace(v->getName(), v);
+    }
+
+    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
+    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
+    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
+    std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(array);
+
+    std::shared_ptr<air::Stmt> stmt = stmtMap.at("a[i][j]");
+    /*
+       `-ImplicitCastExpr 0x14580cda8 <col:16, col:22> 'int' <LValueToRValue>
+        `-ArraySubscriptExpr 0x14580cd88 <col:16, col:22> 'int' lvalue
+          |-ImplicitCastExpr1 0x14580cd58 <col:16, col:19> 'int *' <ArrayToPointerDecay>
+          | `-ArraySubscriptExpr1 0x14580cce8 <col:16, col:19> 'int[2]' lvalue
+          |   |-ImplicitCastExpr2 0x14580ccb8 <col:16> 'int (*)[2]' <ArrayToPointerDecay>
+          |   | `-DeclRefExpr 0x14580cc50 <col:16> 'int[2][2]' lvalue Var 0x14580ca60 'a' 'int[2][2]'
+          |   `-ImplicitCastExpr_i 0x14580ccd0 <col:18> 'int' <LValueToRValue>
+          |     `-DeclRefExpr 0x14580cc70 <col:18> 'int' lvalue Var 0x14580caf8 'i' 'int'
+          `-ImplicitCastExpr 0x14580cd70 <col:21> 'int' <LValueToRValue>
+            `-DeclRefExpr 0x14580cd08 <col:21> 'int' lvalue Var 0x14580cb98 'j' 'int'
+    */
+
+    const clang::Stmt *clangStmt = stmt->getClangStmt();
+    auto *implicitCastExpr = clang::dyn_cast<clang::ImplicitCastExpr>(clangStmt);
+    auto *arraySubscriptExpr = clang::dyn_cast<clang::ArraySubscriptExpr>(implicitCastExpr->getSubExpr());
+    // check type: int[2][2]
+    auto *implicitCastExpr1 = clang::dyn_cast<clang::ImplicitCastExpr>(arraySubscriptExpr->getBase());
+    auto *arraySubscriptExpr1 = clang::dyn_cast<clang::ArraySubscriptExpr>(implicitCastExpr1->getSubExpr());
+    auto *implicitCastExpr2 = clang::dyn_cast<clang::ImplicitCastExpr>(arraySubscriptExpr1->getBase());
+    auto *declRefExpr = clang::dyn_cast<clang::DeclRefExpr>(implicitCastExpr2->getSubExpr());
+    auto *arrayType2 = clang::dyn_cast<clang::ConstantArrayType>(declRefExpr->getType());
+    CHECK(arrayType2 != nullptr);
+    CHECK_EQ(arrayType2->getSize(), 2);
+    auto *implicitCastExpr_i = clang::dyn_cast<clang::ImplicitCastExpr>(arraySubscriptExpr1->getIdx());
+    auto i_value = cp->getExprValue(implicitCastExpr_i);
+    CHECK(i_value != nullptr);
+    CHECK(i_value->isConstant());
+    CHECK_EQ(i_value->getConstantValue(), 2);
+    // check type: int[2]
+    auto *arrayType1 = clang::dyn_cast<clang::ConstantArrayType>(arraySubscriptExpr1->getType());
+    CHECK(arrayType1 != nullptr);
+    CHECK_EQ(arrayType1->getSize(), 2);
+    auto *implicitCastExpr_j = clang::dyn_cast<clang::ImplicitCastExpr>(arraySubscriptExpr->getIdx());
+    auto j_value = cp->getExprValue(implicitCastExpr_j);
+    CHECK(j_value != nullptr);
+    CHECK(j_value->isConstant());
+    CHECK_EQ(j_value->getConstantValue(), 3);
+
+    al::World::getLogger().Success("Finish constant propagation example array ...");
+
+}
+
+TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCall"
+    * doctest::description("testing constant propagation example call")) {
+
+    al::World::getLogger().Progress("Testing constant propagation example call ...");
+
+    std::shared_ptr<graph::CFG> cfg = call->getCFG();
+    std::unordered_map<std::string, std::shared_ptr<air::Stmt>> stmtMap;
+    for (const std::shared_ptr<air::Stmt>& s : call->getStmts()) {
+       al::World::getLogger().Debug(s->str());
+       stmtMap.emplace(s->str(), s);
+    }
+
+    std::unordered_map<std::string, std::shared_ptr<air::Var>> varMap;
+    for (const std::shared_ptr<air::Var>& v : call->getVars()) {
+       varMap.emplace(v->getName(), v);
+    }
+
+    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
+    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
+    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
+    std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(call);
+
+    std::shared_ptr<air::Stmt> stmt = stmtMap.at("foo(1 / zero)");
+    auto *clangStmt = stmt->getClangStmt();
+    auto *callExpr = clang::dyn_cast<clang::CallExpr>(clangStmt);
+    auto *arg0 = callExpr->getArg(0);
+
+    auto arg0_value = cp->getExprValue(arg0);
+    CHECK(arg0_value != nullptr);
+    CHECK(arg0_value->isUndef());
+
+    al::World::getLogger().Success("Finish constant propagation example call ...");
 }
 
 TEST_SUITE_END();

--- a/tests/TestConstantPropagation.cpp
+++ b/tests/TestConstantPropagation.cpp
@@ -15,6 +15,7 @@ namespace dfact = al::analysis::dataflow::fact;
 class ConstPropagationTestFixture {
 protected:
     std::shared_ptr<air::IR> dummy, typeCast, ifElse, binaryOp, loop, incDec, array, call;
+    std::unique_ptr<df::ConstantPropagation> cp;
     
 public:
     ConstPropagationTestFixture() {
@@ -28,6 +29,12 @@ public:
         incDec = world.getMethodBySignature("void ConstPropagation::incDec()")->getIR();
         array = world.getMethodBySignature("int ConstPropagation::array()")->getIR();
         call = world.getMethodBySignature("int ConstPropagation::call()")->getIR();
+
+        std::unique_ptr<cf::AnalysisConfig> analysisConfig;
+        analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
+        cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
+
+        CHECK(analysisConfig == nullptr);
     }
 };
 
@@ -59,9 +66,6 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCaseDummy"
     std::shared_ptr<air::Var> x = varMap.at("x");
     std::shared_ptr<air::Var> y = varMap.at("y");
 
-    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
-    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
-    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
     std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(dummy);
 
     CHECK(result->getOutFact(s1)->get(x)->isUndef());
@@ -101,9 +105,6 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationTypeCase"
     std::shared_ptr<air::Var> y = varMap.at("y");
     std::shared_ptr<air::Var> z = varMap.at("z");
 
-    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
-    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
-    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
     std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(typeCast);
     auto fact = result->getInFact(exit);
 
@@ -147,9 +148,6 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCaseIfElse"
     std::shared_ptr<air::Var> u = varMap.at("u");
     std::shared_ptr<air::Var> v = varMap.at("v");
 
-    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
-    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
-    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
     std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(ifElse);
     auto fact = result->getInFact(exit);
 
@@ -202,9 +200,6 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCaseBinaryOp
     std::shared_ptr<air::Var> RShift = varMap.at("RShift");
     std::shared_ptr<air::Var> zero = varMap.at("zero");
 
-    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
-    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
-    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
     std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(binaryOp);
     CHECK(result->getOutFact(cfg->getEntry())->get(n)->isNAC());
 
@@ -265,9 +260,6 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCaseLoop"
     std::shared_ptr<air::Var> a = varMap.at("a");
     std::shared_ptr<air::Var> c = varMap.at("c");
 
-    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
-    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
-    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
     std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(loop);
 
     auto fact = result->getInFact(exit);
@@ -280,19 +272,19 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCaseLoop"
 
 TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationIncDec"
     * doctest::description("testing constant propagation example inc-dec")) {
-    
+
     al::World::getLogger().Progress("Testing constant propagation example inc-dec ...");
 
     std::shared_ptr<graph::CFG> cfg = incDec->getCFG();
     std::unordered_map<std::string, std::shared_ptr<air::Stmt>> stmtMap;
     for (const std::shared_ptr<air::Stmt>& s : incDec->getStmts()) {
-       al::World::getLogger().Debug(s->str());
-       stmtMap.emplace(s->str(), s);
+    al::World::getLogger().Debug(s->str());
+    stmtMap.emplace(s->str(), s);
     }
 
     std::unordered_map<std::string, std::shared_ptr<air::Var>> varMap;
     for (const std::shared_ptr<air::Var>& v : incDec->getVars()) {
-       varMap.emplace(v->getName(), v);
+    varMap.emplace(v->getName(), v);
     }
 
     std::shared_ptr<air::Stmt> exit = cfg->getExit();
@@ -302,9 +294,6 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationIncDec"
     std::shared_ptr<air::Var> c = varMap.at("c");
     std::shared_ptr<air::Var> d = varMap.at("d");
 
-    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
-    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
-    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
     std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(incDec);
 
     auto fact = result->getInFact(exit);
@@ -328,32 +317,30 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationArray"
     std::shared_ptr<graph::CFG> cfg = array->getCFG();
     std::unordered_map<std::string, std::shared_ptr<air::Stmt>> stmtMap;
     for (const std::shared_ptr<air::Stmt>& s : array->getStmts()) {
-       al::World::getLogger().Debug(s->str());
-       stmtMap.emplace(s->str(), s);
+    al::World::getLogger().Debug(s->str());
+    stmtMap.emplace(s->str(), s);
     }
 
     std::unordered_map<std::string, std::shared_ptr<air::Var>> varMap;
     for (const std::shared_ptr<air::Var>& v : array->getVars()) {
-       varMap.emplace(v->getName(), v);
+    varMap.emplace(v->getName(), v);
     }
 
-    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
-    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
-    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
-    std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(array);
+    std::shared_ptr<dfact::DataflowResult<df::CPFact>> df_result = cp->analyze(array);
+    std::shared_ptr<df::CPResult> result = std::dynamic_pointer_cast<df::CPResult>(df_result);
 
     std::shared_ptr<air::Stmt> stmt = stmtMap.at("a[i][j]");
     /*
-       `-ImplicitCastExpr 0x14580cda8 <col:16, col:22> 'int' <LValueToRValue>
-        `-ArraySubscriptExpr 0x14580cd88 <col:16, col:22> 'int' lvalue
-          |-ImplicitCastExpr1 0x14580cd58 <col:16, col:19> 'int *' <ArrayToPointerDecay>
-          | `-ArraySubscriptExpr1 0x14580cce8 <col:16, col:19> 'int[2]' lvalue
-          |   |-ImplicitCastExpr2 0x14580ccb8 <col:16> 'int (*)[2]' <ArrayToPointerDecay>
-          |   | `-DeclRefExpr 0x14580cc50 <col:16> 'int[2][2]' lvalue Var 0x14580ca60 'a' 'int[2][2]'
-          |   `-ImplicitCastExpr_i 0x14580ccd0 <col:18> 'int' <LValueToRValue>
-          |     `-DeclRefExpr 0x14580cc70 <col:18> 'int' lvalue Var 0x14580caf8 'i' 'int'
-          `-ImplicitCastExpr 0x14580cd70 <col:21> 'int' <LValueToRValue>
-            `-DeclRefExpr 0x14580cd08 <col:21> 'int' lvalue Var 0x14580cb98 'j' 'int'
+    `-ImplicitCastExpr 0x14580cda8 <col:16, col:22> 'int' <LValueToRValue>
+    `-ArraySubscriptExpr 0x14580cd88 <col:16, col:22> 'int' lvalue
+    |-ImplicitCastExpr1 0x14580cd58 <col:16, col:19> 'int *' <ArrayToPointerDecay>
+    | `-ArraySubscriptExpr1 0x14580cce8 <col:16, col:19> 'int[2]' lvalue
+    |   |-ImplicitCastExpr2 0x14580ccb8 <col:16> 'int (*)[2]' <ArrayToPointerDecay>
+    |   | `-DeclRefExpr 0x14580cc50 <col:16> 'int[2][2]' lvalue Var 0x14580ca60 'a' 'int[2][2]'
+    |   `-ImplicitCastExpr_i 0x14580ccd0 <col:18> 'int' <LValueToRValue>
+    |     `-DeclRefExpr 0x14580cc70 <col:18> 'int' lvalue Var 0x14580caf8 'i' 'int'
+    `-ImplicitCastExpr 0x14580cd70 <col:21> 'int' <LValueToRValue>
+     `-DeclRefExpr 0x14580cd08 <col:21> 'int' lvalue Var 0x14580cb98 'j' 'int'
     */
 
     const clang::Stmt *clangStmt = stmt->getClangStmt();
@@ -368,7 +355,7 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationArray"
     CHECK(arrayType2 != nullptr);
     CHECK_EQ(arrayType2->getSize(), 2);
     auto *implicitCastExpr_i = clang::dyn_cast<clang::ImplicitCastExpr>(arraySubscriptExpr1->getIdx());
-    auto i_value = cp->getExprValue(implicitCastExpr_i);
+    auto i_value = result->getExprValue(implicitCastExpr_i);
     CHECK(i_value != nullptr);
     CHECK(i_value->isConstant());
     CHECK_EQ(i_value->getConstantValue(), 2);
@@ -377,7 +364,7 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationArray"
     CHECK(arrayType1 != nullptr);
     CHECK_EQ(arrayType1->getSize(), 2);
     auto *implicitCastExpr_j = clang::dyn_cast<clang::ImplicitCastExpr>(arraySubscriptExpr->getIdx());
-    auto j_value = cp->getExprValue(implicitCastExpr_j);
+    auto j_value = result->getExprValue(implicitCastExpr_j);
     CHECK(j_value != nullptr);
     CHECK(j_value->isConstant());
     CHECK_EQ(j_value->getConstantValue(), 3);
@@ -394,26 +381,24 @@ TEST_CASE_FIXTURE(ConstPropagationTestFixture, "testConstPropagationCall"
     std::shared_ptr<graph::CFG> cfg = call->getCFG();
     std::unordered_map<std::string, std::shared_ptr<air::Stmt>> stmtMap;
     for (const std::shared_ptr<air::Stmt>& s : call->getStmts()) {
-       al::World::getLogger().Debug(s->str());
-       stmtMap.emplace(s->str(), s);
+    al::World::getLogger().Debug(s->str());
+    stmtMap.emplace(s->str(), s);
     }
 
     std::unordered_map<std::string, std::shared_ptr<air::Var>> varMap;
     for (const std::shared_ptr<air::Var>& v : call->getVars()) {
-       varMap.emplace(v->getName(), v);
+    varMap.emplace(v->getName(), v);
     }
 
-    std::unique_ptr<cf::AnalysisConfig> analysisConfig;
-    analysisConfig = std::make_unique<cf::DefaultAnalysisConfig>("constant propagation analysis");
-    std::unique_ptr<df::ConstantPropagation> cp = std::make_unique<df::ConstantPropagation>(analysisConfig);
-    std::shared_ptr<dfact::DataflowResult<df::CPFact>> result = cp->analyze(call);
+    std::shared_ptr<dfact::DataflowResult<df::CPFact>> df_result = cp->analyze(call);
+    std::shared_ptr<df::CPResult> result = std::dynamic_pointer_cast<df::CPResult>(df_result);
 
     std::shared_ptr<air::Stmt> stmt = stmtMap.at("foo(1 / zero)");
     auto *clangStmt = stmt->getClangStmt();
     auto *callExpr = clang::dyn_cast<clang::CallExpr>(clangStmt);
     auto *arg0 = callExpr->getArg(0);
 
-    auto arg0_value = cp->getExprValue(arg0);
+    auto arg0_value = result->getExprValue(arg0);
     CHECK(arg0_value != nullptr);
     CHECK(arg0_value->isUndef());
 


### PR DESCRIPTION
添加常量传播对更多语句的支持，并提过获取每个 clang::Stmt 最终计算结果 CPValue 的接口